### PR TITLE
Automatic dependency checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Laravel in root directory
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "[Laravel]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Laravel in root directory
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "[Laravel]"
+      prefix: "[SDK PHP]"


### PR DESCRIPTION
Dependabot will automatically open pull requests if a dependency needs to be updated.

This also requires enabling Dependabot in the security settings of the repository.

Example: [https://github.com/abcdan/sdk-php/pull/1](https://github.com/abcdan/sdk-php/pull/1)