### PR TITLE
[Fix]: Added static types to dataProviders

### DIFF
--- a/Tests/Feature/Order/ShowOrderTest.php
+++ b/Tests/Feature/Order/ShowOrderTest.php
@@ -72,7 +72,7 @@ class ShowOrderTest extends TestCase
     /**
      * Data provider for show_none_loaded_relationships.
      */
-    public function relationsProvider(): array
+    public static function relationsProvider(): array
     {
         return [
             'billing'        => ['billing'],

--- a/Tests/Feature/Order/StoreOrderTest.php
+++ b/Tests/Feature/Order/StoreOrderTest.php
@@ -130,7 +130,7 @@ class StoreOrderTest extends TestCase
 
     /**
      * @test
-     * @dataProvider convert_order_fields_data_provider
+     * @dataProvider convertOrderFieldsDataProvider
      */
     public function convert_order_fields(string $method, string $bodyField, $value): void
     {
@@ -141,7 +141,7 @@ class StoreOrderTest extends TestCase
         static::assertEquals($value, $body[$bodyField]);
     }
 
-    public static function convert_order_fields_data_provider(): array
+    public static function convertOrderFieldsDataProvider(): array
     {
         return [
             'isHidden' => [

--- a/Tests/Feature/Order/StoreOrderTest.php
+++ b/Tests/Feature/Order/StoreOrderTest.php
@@ -141,7 +141,7 @@ class StoreOrderTest extends TestCase
         static::assertEquals($value, $body[$bodyField]);
     }
 
-    public function convert_order_fields_data_provider(): array
+    public static function convert_order_fields_data_provider(): array
     {
         return [
             'isHidden' => [

--- a/Tests/Feature/Product/ShowProductTest.php
+++ b/Tests/Feature/Product/ShowProductTest.php
@@ -59,7 +59,7 @@ class ShowProductTest extends TestCase
     /**
      * Data provider for fetch_none_loaded_relationships.
      */
-    public function relationsProvider(): array
+    public static function relationsProvider(): array
     {
         return [
             'pricing' => ['pricing'],

--- a/Tests/Feature/Subscription/ShowSubscriptionTest.php
+++ b/Tests/Feature/Subscription/ShowSubscriptionTest.php
@@ -57,7 +57,7 @@ class ShowSubscriptionTest extends TestCase
     /**
      * Data provider for show_none_loaded_relationships.
      */
-    public function relationsProvider(): array
+    public static function relationsProvider(): array
     {
         return [
             'billing' => ['billing'],


### PR DESCRIPTION
Dit fixed een probleem: 'Non-static data providers are deprecated in PHPUnit 10'. Hoewel dit nu nog geen effect heeft op tests, is het wel handig om dit al gefixt te hebben :)

[Zie voor meer informatie](https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09)

![CleanShot 2024-08-02 at 19 15 21@2x](https://github.com/user-attachments/assets/fddeaf8e-55a2-4bf9-925b-d08899f8a289)
