### PR TITLE
Feature: Change base URL

### DIFF
--- a/src/Service/Client.php
+++ b/src/Service/Client.php
@@ -27,7 +27,7 @@ class Client implements ClientInterface
     private const METHOD_PATCH  = 'PATCH';
     private const METHOD_POST   = 'POST';
 
-    private const BASE_API_URL_PRODUCTION = 'https://api.plugandpay.nl';
+    private const BASE_API_URL_PRODUCTION = 'https://api.plugandpay.com';
 
     /**
      * @var GuzzleClient


### PR DESCRIPTION
We now host the API on .com, .nl does still work but for consistency updated it to .com

