### PR TITLE
Hotfix: handle laravel/passport v13 error messages

### DIFF
--- a/src/Exception/ExceptionFactory.php
+++ b/src/Exception/ExceptionFactory.php
@@ -49,9 +49,9 @@ class ExceptionFactory
         if ($body['error']) {
             return json_encode(
                 [
-                    'error' => $body['error'],
+                    'error'             => $body['error'],
                     'error_description' => $body['error_description'],
-                    'hint' => $body['hint'],
+                    'hint'              => $body['hint'],
                 ],
                 JSON_THROW_ON_ERROR,
             );

--- a/src/Exception/ExceptionFactory.php
+++ b/src/Exception/ExceptionFactory.php
@@ -30,7 +30,7 @@ class ExceptionFactory
             case Response::HTTP_BAD_REQUEST:
                 $body = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
-                return new \RuntimeException("Error: $status; Body: " . $body['message']);
+                return new \RuntimeException("Error: $status; Body: " . self::getErrorMessage($body));
             default:
                 if ($status < 400) {
                     return null;
@@ -38,5 +38,25 @@ class ExceptionFactory
 
                 return new \RuntimeException("Error: $status; Known body: $body");
         }
+    }
+
+    private static function getErrorMessage(mixed $body): string
+    {
+        if (isset($body['message'])) {
+            return $body['message'];
+        }
+
+        if ($body['error']) {
+            return json_encode(
+                [
+                    'error' => $body['error'],
+                    'error_description' => $body['error_description'],
+                    'hint' => $body['hint'],
+                ],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        return 'unknown error';
     }
 }


### PR DESCRIPTION
Examples:
```json
  {
    "error": "invalid_request",
    "error_description": "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.",
    "hint": "Check the `refresh_token` parameter"
  }
```

```json
  {
    "error": "invalid_grant",
    "error_description": "The refresh token is invalid.",
    "hint": "Cannot decrypt the refresh token"
  }
```
